### PR TITLE
Static yield and delay

### DIFF
--- a/TeensyThreads.h
+++ b/TeensyThreads.h
@@ -286,9 +286,9 @@ public:
 
   // Yield current thread's remaining time slice to the next thread, causing immediate
   // context switch
-  void yield();
+  static void yield();
   // Wait for milliseconds using yield(), giving other slices your wait time
-  void delay(int millisecond);
+  static void delay(int millisecond);
   
   // Start/restart threading system; returns previous state: STARTED, STOPPED, FIRST_RUN
   // can pass the previous state to restore


### PR DESCRIPTION
Making the yield and delay methods static so that no instance of a thread is required to call these methods. This is a simple change as the methods do not rely on members of the Threads class.