### PR TITLE
Remove utils/debug.h in TeensyThreads.cpp

### DIFF
--- a/TeensyThreads.cpp
+++ b/TeensyThreads.cpp
@@ -26,8 +26,6 @@
 #include <Arduino.h>
 #include <string.h>
 
-#include "utils/debug.h"
-
 #ifndef __IMXRT1062__
 
 #include <IntervalTimer.h>

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=TeensyThreads
-version=1.0.1
+version=1.0.2
 author=Fernando Trias
 maintainer=Fernando Trias
 sentence=Pre-emptive threads for the Teensy 3 and 4 platform from PJRC.


### PR DESCRIPTION
I got the following error so I want to remove the line.
```
/home/asuki/.platformio/packages/framework-arduinoteensy/libraries/TeensyThreads/TeensyThreads.cpp:29:25: fatal error: utils/debug.h: No such file or directory
compilation terminated.
*** [.pio/build/fukaya02/libebe/TeensyThreads/TeensyThreads.cpp.o] Error 1
```

Platform information on PlatformIO.
```
Platform teensy
--------
Updating platformio/teensy                    4.14.0                             [Up-to-date]
Updating platformio/toolchain-atmelavr        1.50400.190710 @ ~1.50400.0        [Up-to-date]
Updating platformio/toolchain-gccarmnoneeabi  1.50401.190816 @ ~1.50401.0        [Up-to-date]
Updating platformio/framework-arduinoteensy   1.155.0 @ ~1.155.0                 [Up-to-date]
Updating platformio/tool-teensy               1.155.0 @ <2                       [Up-to-date]
```

The error is also mentioned in https://github.com/ftrias/TeensyThreads/issues/29

Thank you.